### PR TITLE
ManifestV3 messages, extension startup and popup refresh improvements

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1,8 +1,62 @@
-// Define a variable to store the number of live channels
-let liveChannelsCount = 0;
+importScripts('util.js');
+
+// Set up message listeners and refresh data on browser startup and extension reload (dev/unpacked)
+const launch = async () => {
+    // Listen for messages to fetch Twitch auth token
+    chrome.runtime.onMessage.addListener((request) => {
+        if (request.message === "fetch-twitch-auth-token") {
+            getTwitchAuth();
+        }
+        return true;
+    });
+
+    // Listen for messages to refresh Twitch streams
+    chrome.runtime.onMessage.addListener((request) => {
+        if (request.message === "refresh-twitch-streams") {
+            console.log("Refreshing Twitch streams...");
+            getLiveTwitchStreams();
+        }
+        return true;
+    });
+
+    // Create an alarm to validate Twitch token every hour
+    chrome.alarms.onAlarm.addListener((alarm) => {
+        if (alarm.name === "validateTwitchTokenAlarm") {
+            validateTwitchToken();
+        }
+    });
+    chrome.alarms.create("validateTwitchTokenAlarm", { periodInMinutes: 60 });
+
+    // Update streams update every 5 minutes
+    chrome.alarms.onAlarm.addListener((alarm) => {
+        if (alarm.name === "updateStreamsAlarm") {
+            updateStreamsPeriodically();
+        }
+    });
+    chrome.alarms.create("updateStreamsAlarm", { periodInMinutes: 5 });
+
+    // NOTE: it is necessary to await these, otherwise the functions would run in parallel, before the streams are fetched.
+    await validateTwitchToken();
+    await getLiveTwitchStreams();
+    await updateBadge();
+}
+
+chrome.runtime.onStartup.addListener(async () => launch());
+chrome.runtime.onInstalled.addListener(async () => launch());
+
+// Store the number of live channels
+// In Manifest V3, we have to use storage for this, as the service worker is not persistent
+chrome.storage.local.set({ liveChannelsCount: 0 });
+
+// Function that returns the number of live channels
+const getLiveChannelsCount = async () => {
+    let result = await chrome.storage.local.get("liveChannelsCount");
+    return result.liveChannelsCount;
+};
 
 // Function to update the badge text and color
-const updateBadge = () => {
+const updateBadge = async () => {
+    const liveChannelsCount = await getLiveChannelsCount();
     const badgeText = liveChannelsCount > 0 ? liveChannelsCount.toString() : "";
     chrome.action.setBadgeText({ text: badgeText });
     chrome.action.setBadgeBackgroundColor({ color: "#67676b" });
@@ -13,8 +67,9 @@ const TWITCH_APP_TOKEN = "veho7ytn25l8a9dpgfkk79sqgey43j";
 const redirectURL = chrome.identity.getRedirectURL();
 
 // Function to send live channels count to the popup and update badge
-const sendLiveChannelsCountToPopup = () => {
-    chrome.runtime.sendMessage({ message: "update-badge", liveChannelsCount });
+// TODO: revise!
+const sendLiveChannelsCountToPopup = async () => {
+    liveChannelsCount = await getLiveChannelsCount();
     updateBadge();
 };
 
@@ -25,33 +80,6 @@ const handleTwitchUnauthorized = () => {
         twitchIsValidated: false,
         twitchUserId: null,
         twitchStreams: null,
-    });
-};
-
-// Function to validate the Twitch access token
-const validateTwitchToken = async () => {
-    chrome.storage.local.get("twitchAccessToken", async (res) => {
-        const accessToken = res.twitchAccessToken;
-        if (!accessToken) return;
-        await fetch("https://id.twitch.tv/oauth2/validate", {
-                headers: { Authorization: `Bearer ${accessToken}` },
-            })
-            .then((response) => response.json())
-            .then((response) => {
-                if (response.expires_in === 0) {
-                    handleTwitchUnauthorized();
-                } else {
-                    chrome.storage.local.set({
-                        twitchIsValidated: true,
-                        twitchUserId: response["user_id"],
-                    });
-                    getLiveTwitchStreams();
-                }
-            })
-            .catch((error) => {
-                handleTwitchUnauthorized();
-                console.error(error);
-            });
     });
 };
 
@@ -84,42 +112,60 @@ const getTwitchAuth = () => {
     );
 };
 
-// Set interval to validate Twitch token periodically
-setInterval(validateTwitchToken, 1000 * 60 * 60);
-validateTwitchToken();
+// Function to validate the Twitch access token
+const validateTwitchToken = async () => {
+    chrome.storage.local.get("twitchAccessToken", async (res) => {
+        const accessToken = res.twitchAccessToken;
+        if (!accessToken) return;
+        await fetch("https://id.twitch.tv/oauth2/validate", {
+            headers: { Authorization: `Bearer ${accessToken}` },
+        })
+            .then((response) => response.json())
+            .then(async (response) => {
+                if (response.expires_in === 0) {
+                    handleTwitchUnauthorized();
+                } else {
+                    chrome.storage.local.set({
+                        twitchIsValidated: true,
+                        twitchUserId: response["user_id"],
+                    });
+                }
+            })
+            .catch((error) => {
+                handleTwitchUnauthorized();
+                console.error(error);
+            });
+    });
+};
 
-// Listen for messages to fetch Twitch auth token
-chrome.runtime.onMessage.addListener((request) => {
-    if (request.message === "fetch-twitch-auth-token") {
-        getTwitchAuth();
-    }
-});
+
 
 // Function to get live Twitch streams
 const getLiveTwitchStreams = async () => {
+
     const storageItems = [
         "twitchIsValidated",
         "twitchAccessToken",
         "twitchUserId",
     ];
+
     chrome.storage.local.get(storageItems, (res) => {
         if (!res.twitchIsValidated) return;
-        const followUrl =
-            "https://api.twitch.tv/helix/streams/followed" +
-            `?&first=100&user_id=${res.twitchUserId}`;
+
+        const followUrl = "https://api.twitch.tv/helix/streams/followed" + `?&first=100&user_id=${res.twitchUserId}`;
         fetch(followUrl, {
-                headers: {
-                    Authorization: `Bearer ${res.twitchAccessToken}`,
-                    "Client-ID": TWITCH_APP_TOKEN,
-                },
-            })
-            .then((response) => {
-                if (response.status !== 200) {
-                    handleTwitchUnauthorized();
-                    throw new Error("An error occurred");
-                }
-                return response.json();
-            })
+            headers: {
+                Authorization: `Bearer ${res.twitchAccessToken}`,
+                "Client-ID": TWITCH_APP_TOKEN,
+            },
+        }
+        ).then((response) => {
+            if (response.status !== 200) {
+                handleTwitchUnauthorized();
+                throw new Error("An error occurred");
+            }
+            return response.json();
+        })
             .then((response) => {
                 chrome.storage.local.set({
                     twitchStreams: response.data.map((stream) => ({
@@ -132,8 +178,8 @@ const getLiveTwitchStreams = async () => {
                     })),
                 });
 
-                liveChannelsCount = response.data.length; // Update live channels count
-                sendLiveChannelsCountToPopup(); // Send live channels count to the popup
+                chrome.storage.local.set({ liveChannelsCount: response.data.length }); // Store live channels count
+                updateBadge(); // Update badge
             })
             .catch((error) => {
                 handleTwitchUnauthorized();
@@ -142,53 +188,16 @@ const getLiveTwitchStreams = async () => {
     });
 };
 
-// Listen for messages to refresh Twitch streams
-chrome.runtime.onMessage.addListener((request) => {
-    if (request.message === "refresh-twitch-streams") {
-        getLiveTwitchStreams();
-    }
-});
-
-// Function to get formatted time passed since stream started
-const getTimePassed = (startTime) => {
-    let elapsedTime = Date.now() - Date.parse(startTime);
-    const hours = Math.floor(elapsedTime / 3600000);
-    const minutes = Math.floor((elapsedTime % 3600000) / 60000);
-    const seconds = Math.floor((elapsedTime % 60000) / 1000);
-
-    const format = (s) => (s < 10 ? `0${s}` : s);
-
-    const formattedHours = hours > 0 ? `${hours}:` : '';
-    const formattedMinutes = hours > 0 || minutes >= 10 ? format(minutes) : minutes;
-    const formattedSeconds = `${format(seconds)}`;
-
-    return `${formattedHours}${formattedMinutes}:${formattedSeconds}`;
-};
-
 // Function to handle the periodic update of streams
 const updateStreamsPeriodically = () => {
     // Refresh Twitch streams in the background
-    chrome.runtime.sendMessage({ message: "refresh-twitch-streams" });
+    getLiveTwitchStreams();
 
     // Update the badge count based on the latest data
     chrome.storage.local.get("twitchStreams", (res) => {
         if (res.twitchStreams) {
-            liveChannelsCount = res.twitchStreams.length;
+            chrome.storage.local.set({ liveChannelsCount: res.twitchStreams.length });
             updateBadge();
         }
     });
 };
-
-// Update streams update every 5 minutes
-chrome.alarms.create("updateStreamsAlarm", { periodInMinutes: 5 });
-chrome.alarms.onAlarm.addListener(updateStreamsPeriodically);
-
-// Listen for messages from the popup
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    if (request.message === "update-badge") {
-        updateBadge();
-    }
-});
-
-// Initial update when the extension is loaded
-updateStreamsPeriodically();

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -171,7 +171,6 @@ const refreshTwitchStreams = () => {
 // Function to handle the refresh button click
 const handleRefreshButtonClick = () => {
     filterInput.value = ""; // Clear the search input
-    refreshTwitchStreams();
     loadTwitchContent();
 };
 
@@ -184,7 +183,6 @@ loadTwitchContent();
 
 // Automatically refresh streams every minute (when popup is "open")
 setInterval(() => {
-    refreshTwitchStreams();
     loadTwitchContent();
 }, 1000 * 60);
 /*}, 100000 * 60);*/

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -182,7 +182,7 @@ const setupAutoRefresh = () => {
     // Automatically refresh streams every minute (when popup is "open")
     setInterval(async () => {
         await loadTwitchContent();
-    }, 1000);
+    }, 1000 * 60);
 };
 
 // Reload popup on successful authentication

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -45,16 +45,6 @@ const formatViewerCount = (count) => {
     return count.toString().replace(/\B(?=(\d{3})+(?!\d))/g, " ");
 };
 
-// Define a variable to store the number of live channels
-let liveChannelsCount = 0;
-
-// Function to update the badge text and color on the extension icon
-const updateBadge = () => {
-    const badgeText = liveChannelsCount > 0 ? liveChannelsCount.toString() : "";
-    chrome.browserAction.setBadgeText({ text: badgeText });
-    chrome.browserAction.setBadgeBackgroundColor({ color: "#67676b" });
-};
-
 // Open stream in new window and player settings
 const openStream = (stream) => {
     const openInPlayerToggle = document.getElementById("openInPlayerToggle");
@@ -146,11 +136,6 @@ const loadTwitchContent = () => {
                 });
 
                 contentSection.replaceChildren(...streamList);
-
-                // Update the badge count based on the latest data
-                liveChannelsCount = res.twitchStreams.length;
-
-                //updateBadge();
             } else {
                 // Display a message when no matching results are found
                 const noResultsMessage = document.createElement("div");
@@ -186,12 +171,3 @@ setInterval(() => {
     loadTwitchContent();
 }, 1000 * 60);
 /*}, 100000 * 60);*/
-
-
-chrome.runtime.onMessage.addListener((request) => {
-    if (request.message === "update-badge") {
-        const badgeText = request.liveChannelsCount > 0 ? request.liveChannelsCount.toString() : "";
-        chrome.action.setBadgeText({ text: badgeText });
-        chrome.action.setBadgeBackgroundColor({ color: "#67676b" });
-    }
-});


### PR DESCRIPTION
- Fixed MV3 `sendMessage()`-related errors, made them asynchronous
- Added proper extension startup/reload routines using Chrome's `onStartup` and `onInstalled` listeners
- Made the popup automatically fetch and show streams on successful authorization, no longer requiring the user to close and re-open the popup manually
- Made the popup fetch streams asynchronously
- Changed the stream count to use the new storage API, as the service worker isn't persistent
- Optimized away some redundant pieces of code