### PR TITLE
fix(popup): correct time sorting and badge lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix time sorting broken for non-US locales by storing raw ISO (`startedAt`/`startedAtISO`) and sorting on it; recompute `liveTime` in popup via `getTimePassed` so uptime ticks correctly (B1)
+- Fix badge count reset to 0 on every service-worker wake by removing unconditional `set({liveChannelsCount:0})` and using fallback `get({liveChannelsCount:0})` (B2)
+- Fix `ReferenceError: error is not defined` in token validation and prevent transient 429/500 from wiping auth — only clear on 401/403 (B4)
+- Fix implicit global `value` leak in background startup alarm (B3)
+- Fix followed-streams URL typo `?&first` → `?first` (B5)
+
 ## [1.3.3] - 2024-02-22
 
 ### Enhancements

--- a/popup.html
+++ b/popup.html
@@ -188,6 +188,7 @@
         <div class="cm-divider"></div>
         <div class="context-item context-item-go-to-category">Go to category</div>
     </div>
+    <script src="src/js/util.js"></script>
     <script src="src/js/main.js"></script>
     <script src="src/js/settings.js"></script>
 </body>

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -70,7 +70,7 @@ const createUpdateStreamsAlarm = (updateRateMin) => {
 };
 
 chrome.storage.local.get({ backgroundUpdateRateMin: 5 }, (data) => {
-    value = data.backgroundUpdateRateMin;
+    const value = data.backgroundUpdateRateMin;
     console.log(`[startup] Background update rate: ${value} minutes`);
     createUpdateStreamsAlarm(value);
 });
@@ -95,11 +95,11 @@ chrome.runtime.onInstalled.addListener(async () => launch());
 
 // Store the number of live channels
 // In Manifest V3, we have to use storage for this, as the service worker is not persistent
-chrome.storage.local.set({ liveChannelsCount: 0 });
+// Initial value is set only on install; fallback to 0 otherwise (avoid clobber on every SW wake)
 
 // Function that returns the number of live channels
 const getLiveChannelsCount = async () => {
-    let result = await chrome.storage.local.get("liveChannelsCount");
+    let result = await chrome.storage.local.get({ liveChannelsCount: 0 });
     return result.liveChannelsCount;
 };
 
@@ -179,7 +179,7 @@ const validateTwitchToken = async () => {
             headers: { Authorization: `Bearer ${accessToken}` },
         });
         if (response.status !== 200) {
-            throw new Error(error);
+            throw new Error('validate failed: ' + response.status);
         }
         response = await response.json();
 
@@ -193,7 +193,10 @@ const validateTwitchToken = async () => {
             });
         }
     } catch (error) {
-        handleTwitchUnauthorized();
+        const msg = String(error && error.message || '');
+        if (msg.includes('401') || msg.includes('403') || msg.includes('Token expiry')) {
+            handleTwitchUnauthorized();
+        }
         console.error(error);
     }
 };
@@ -209,7 +212,7 @@ const getLiveTwitchStreams = async () => {
     const res = await chrome.storage.local.get(storageItems);
     if (!res.twitchIsValidated) return;
 
-    const followUrl = "https://api.twitch.tv/helix/streams/followed" + `?&first=100&user_id=${res.twitchUserId}`;
+    const followUrl = "https://api.twitch.tv/helix/streams/followed" + `?first=100&user_id=${res.twitchUserId}`;
     try {
         let response = await fetch(followUrl, {
             headers: {
@@ -232,7 +235,9 @@ const getLiveTwitchStreams = async () => {
                 channelName: stream["user_name"],
                 viewerCount: stream["viewer_count"],
                 liveTime: getTimePassed(stream["started_at"]),
-                startedAt: getStartedAtTime(stream["started_at"]),
+                startedAt: stream["started_at"],
+                startedAtDisplay: getStartedAtTime(stream["started_at"]),
+                startedAtISO: stream["started_at"],
             })),
         });
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -96,8 +96,8 @@ const loadTwitchContent = async () => {
                 break;
             case "Uptime":
                 filteredStreams.sort((a, b) => {
-                    const aUptime = new Date(a.startedAt).getTime();
-                    const bUptime = new Date(b.startedAt).getTime();
+                    const aUptime = new Date(a.startedAtISO || a.startedAt).getTime() || 0;
+                    const bUptime = new Date(b.startedAtISO || b.startedAt).getTime() || 0;
                     return aUptime - bUptime;
                 });
                 break;
@@ -109,22 +109,16 @@ const loadTwitchContent = async () => {
                 break;
             case "Recently Started":
                 filteredStreams.sort((a, b) => {
-                    const aStarted = new Date(a.startedAt).getTime();
-                    const bStarted = new Date(b.startedAt).getTime();
+                    const aStarted = new Date(a.startedAtISO || a.startedAt).getTime() || 0;
+                    const bStarted = new Date(b.startedAtISO || b.startedAt).getTime() || 0;
                     return bStarted - aStarted;
                 });
                 break;
             case "Longest Running":
                 filteredStreams.sort((a, b) => {
-                    const aStarted = new Date(a.startedAt).getTime();
-                    const bStarted = new Date(b.startedAt).getTime();
-                    const aRunning = a.runningAt ? new Date(a.runningAt).getTime() : Date.now();
-                    const bRunning = b.runningAt ? new Date(b.runningAt).getTime() : Date.now();
-                    const aDuration = aRunning - aStarted;
-                    const bDuration = bRunning - bStarted;
-
-                    // console.log("aDuration:", aDuration, "bDuration:", bDuration); // debugging
-                    return bDuration - aDuration;
+                    const aStarted = new Date(a.startedAtISO || a.startedAt).getTime() || 0;
+                    const bStarted = new Date(b.startedAtISO || b.startedAt).getTime() || 0;
+                    return aStarted - bStarted;
                 });
                 break;
             default:
@@ -150,8 +144,9 @@ const loadTwitchContent = async () => {
 
                 const uptime = document.createElement("div");
                 uptime.setAttribute("class", "stream-uptime");
-                uptime.innerHTML = `${stream.liveTime}`;
-                uptime.setAttribute("title", `Live since ${stream.startedAt}`);
+                const liveTime = typeof getTimePassed === 'function' ? getTimePassed(stream.startedAtISO || stream.startedAt) : stream.liveTime;
+                uptime.textContent = liveTime;
+                uptime.setAttribute("title", `Live since ${stream.startedAtDisplay || stream.startedAt}`);
                 streamThumbnail.appendChild(uptime);
 
                 const thumbnail = document.createElement("img");


### PR DESCRIPTION
Fixes sorting, badge, and token validation (audit B1, B2, B3, B4, B5).

### What & why
- `startedAt` was locale string (`Intl.DateTimeFormat`) then parsed with `new Date(formatted)` → `NaN` outside en-US. Sorting for Uptime / Recently Started / Longest Running shuffled.
- `liveChannelsCount` was unconditionally `set({0})` on every SW wake (MV3 restarts) → clobbered persisted count.
- `validateTwitchToken` threw `new Error(error)` where `error` undefined → always wiped auth on transient 429/500.
- Alarm init leaked global `value`, followed URL had `?&first`.

### Touched areas
- `src/js/background.js:73,98,182,212,235` — ISO store (`startedAt`/`startedAtDisplay`/`startedAtISO`), badge fallback, error handling, URL fix, global fix
- `src/js/main.js:99,147` — sort on `startedAtISO||startedAt`, recompute `liveTime` in popup, simplify Longest Running
- `popup.html:191` — load `src/js/util.js` before `main.js` for live recompute
- `CHANGELOG.md` — Unreleased notes

### Testing
- [x] `manifest.json` valid, zip `manifest.json` at root (`zipfile` check)
- [ ] Manual: Load unpacked, sort toggles (Uptime/Started/Running) stable, uptime ticks, badge persists after reload, revoke token → 401 clears, 500 keeps
- [x] CI green expected

---
Built with muse-spark-1.2-contributor-free in the OpenCode harness.