### PR TITLE
fix(security): harden auth, messages and XSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `ReferenceError: error is not defined` in token validation and prevent transient 429/500 from wiping auth — only clear on 401/403 (B4)
 - Fix implicit global `value` leak in background startup alarm (B3)
 - Fix followed-streams URL typo `?&first` → `?first` (B5)
+- Fix XSS via unsanitized channel/category/search — use `textContent` and `encodeURIComponent` for URLs and messages (B6)
+- Fix brittle token extraction via `split` by using `URL` + `URLSearchParams` (S3)
+- Fix duplicate `onMessage`/`onAlarm` listeners and unhandled `Receiving end does not exist` by merging handlers and guarding `sendMessage` (S4)
+
+### Added
+
+- Add `host_permissions` for `https://api.twitch.tv/*` and `https://id.twitch.tv/*` (S1)
 
 ## [1.3.3] - 2024-02-22
 

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,10 @@
         "storage",
         "identity"
     ],
+    "host_permissions": [
+        "https://api.twitch.tv/*",
+        "https://id.twitch.tv/*"
+    ],
     "background":
     {
         "service_worker": "src/js/background.js"

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1,41 +1,30 @@
 importScripts('util.js');
 
-// Set up listeners and alarms: 
-//
-// Listen for messages to fetch Twitch auth token
-chrome.runtime.onMessage.addListener(async (request) => {
-    if (request.message === "fetch-twitch-auth-token") {
-        const result = await getTwitchAuth();
-        if (result === true && request.popup === true) {
+// Set up listeners and alarms
+chrome.runtime.onMessage.addListener((request) => {
+    (async () => {
+        if (request.message === "fetch-twitch-auth-token") {
+            const result = await getTwitchAuth();
+            if (result === true && request.popup === true) {
+                await getLiveTwitchStreams();
+                chrome.runtime.sendMessage({ message: "popup-auth-success" }).catch(() => {});
+            }
+        } else if (request.message === "refresh-twitch-streams") {
+            console.log("Refreshing Twitch streams...");
             await getLiveTwitchStreams();
-            await chrome.runtime.sendMessage({ message: "popup-auth-success" });
         }
-    }
+    })();
     return true;
 });
 
-// Listen for messages to refresh Twitch streams
-chrome.runtime.onMessage.addListener(async (request) => {
-    if (request.message === "refresh-twitch-streams") {
-        console.log("Refreshing Twitch streams...");
-        await getLiveTwitchStreams();
-    }
-    return true;
-});
-
-// Create an alarm to validate Twitch token every hour
-chrome.alarms.onAlarm.addListener((alarm) => {
-    if (alarm.name === "validateTwitchTokenAlarm") {
-        validateTwitchToken();
-    }
-});
 chrome.alarms.create("validateTwitchTokenAlarm", { periodInMinutes: 60 });
 
 let lastUpdate = new Date();
 
-// Update streams (badge) in background, periodically
 chrome.alarms.onAlarm.addListener((alarm) => {
-    if (alarm.name === "updateStreamsAlarm") {
+    if (alarm.name === "validateTwitchTokenAlarm") {
+        validateTwitchToken();
+    } else if (alarm.name === "updateStreamsAlarm") {
         const updateTime = new Date();
         const diff = Math.abs(updateTime - lastUpdate);
         const diffSeconds = diff / 1000;
@@ -132,19 +121,23 @@ const handleTwitchUnauthorized = () => {
 
 // Function to store the Twitch access token
 const storeTwitchToken = async (url) => {
-    if (url) {
-        const tokenParam = url.split("#")[1];
-        if (tokenParam) {
-            const token = tokenParam.split("=")[1].split("&")[0];
+    if (!url) {
+        console.error("URL is undefined");
+        return false;
+    }
+    try {
+        const hash = new URL(url).hash.slice(1);
+        const token = new URLSearchParams(hash).get("access_token");
+        if (token) {
             chrome.storage.local.set({ twitchAccessToken: token });
             await validateTwitchToken();
-        } else {
-            console.error("Token parameter not found in the URL");
+            return true;
         }
-    } else {
-        console.error("URL is undefined");
+        console.error("Token parameter not found in the URL");
+    } catch (e) {
+        console.error(e);
     }
-    return true;
+    return false;
 };
 
 // Function to initiate Twitch authentication

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -44,11 +44,11 @@ const openStream = (stream) => {
         const openInPlayer = openInPlayerToggle.checked;
         const openInNewWindow = openInNewWindowToggle.checked;
 
-        const baseStreamUrl = `https://www.twitch.tv/${stream.channelName}`;
+        const baseStreamUrl = `https://www.twitch.tv/${encodeURIComponent(stream.channelName)}`;
         let url;
 
         if (openInPlayer) {
-            url = `https://player.twitch.tv/?channel=${stream.channelName}&parent=twitch-live`;
+            url = `https://player.twitch.tv/?channel=${encodeURIComponent(stream.channelName)}&parent=twitch-live`;
         } else {
             url = baseStreamUrl;
         }
@@ -165,7 +165,7 @@ const loadTwitchContent = async () => {
 
                 const channel = document.createElement("span");
                 channel.setAttribute("class", "stream-channel-name");
-                channel.innerHTML = stream.channelName;
+                channel.textContent = stream.channelName;
                 channelContainer.appendChild(channel);
 
                 const raidButton = document.createElement("button");
@@ -191,7 +191,7 @@ const loadTwitchContent = async () => {
                     // Create a new timedAlert
                     const newTimedAlert = document.createElement("div");
                     newTimedAlert.classList.add("timed-alert");
-                    newTimedAlert.innerHTML = message;
+                    newTimedAlert.textContent = message;
 
                     document.body.appendChild(newTimedAlert);
 
@@ -238,8 +238,8 @@ const loadTwitchContent = async () => {
 
                 const categoryAndViewCount = document.createElement("span");
                 categoryAndViewCount.setAttribute("class", "stream-category");
-                categoryAndViewCount.innerHTML = `${stream.gameName}`;
-                categoryAndViewCount.setAttribute("title", `${stream.gameName}`);
+                categoryAndViewCount.textContent = stream.gameName;
+                categoryAndViewCount.setAttribute("title", stream.gameName);
                 streamDetails.appendChild(categoryAndViewCount);
 
                 const title = document.createElement("span");
@@ -270,7 +270,7 @@ const loadTwitchContent = async () => {
 
             const searchOnTwitch = document.createElement("a")
             searchOnTwitch.setAttribute("class", "search-on-twitch-link")
-            searchOnTwitch.setAttribute("href", `https://www.twitch.tv/search?term=${searchTerm}`)
+            searchOnTwitch.setAttribute("href", `https://www.twitch.tv/search?term=${encodeURIComponent(searchTerm)}`)
             searchOnTwitch.setAttribute("target", "_blank")
             searchOnTwitch.innerHTML = `Search on Twitch&nbsp;<i class="fa-solid fa-arrow-up-right-from-square search-on-twitch-link-icon"></i>`
             noResultsMessage.appendChild(searchOnTwitch)
@@ -399,8 +399,8 @@ document.addEventListener('contextmenu', (event) => {
     const streamContainer = event.target.closest('.stream-container');
     if (streamContainer) {
         event.preventDefault();
-        currentChannelName = streamContainer.querySelector('.stream-channel-name').innerHTML.trim();
-        currentCategoryName = streamContainer.querySelector('.stream-category').innerText.split(' - ')[0].trim();
+        currentChannelName = streamContainer.querySelector('.stream-channel-name').textContent.trim();
+        currentCategoryName = streamContainer.querySelector('.stream-category').textContent.split(' - ')[0].trim();
         const mouseX = event.clientX;
         const mouseY = event.clientY;
         hideContextMenu();
@@ -494,12 +494,12 @@ document.addEventListener('mousedown', (event) => {
 });
 
 // Defined separate functions to handle each context menu item click
-const handleOpenChannel = () => openLink(`https://www.twitch.tv/${currentChannelName}`);
-const handleOpenPlayer = () => openLinkInPopup(`https://player.twitch.tv/?channel=${currentChannelName}&parent=twitch-live`);
-const handleOpenChat = () => openLink(`https://www.twitch.tv/popout/${currentChannelName}/chat`);
-const handleOpenAbout = () => openLink(`https://www.twitch.tv/${currentChannelName}/about`);
-const handleOpenVideos = () => openLink(`https://www.twitch.tv/${currentChannelName}/videos`);
-const handleOpenClips = () => openLink(`https://www.twitch.tv/${currentChannelName}/clips?filter=clips&range=7d`);
+const handleOpenChannel = () => openLink(`https://www.twitch.tv/${encodeURIComponent(currentChannelName)}`);
+const handleOpenPlayer = () => openLinkInPopup(`https://player.twitch.tv/?channel=${encodeURIComponent(currentChannelName)}&parent=twitch-live`);
+const handleOpenChat = () => openLink(`https://www.twitch.tv/popout/${encodeURIComponent(currentChannelName)}/chat`);
+const handleOpenAbout = () => openLink(`https://www.twitch.tv/${encodeURIComponent(currentChannelName)}/about`);
+const handleOpenVideos = () => openLink(`https://www.twitch.tv/${encodeURIComponent(currentChannelName)}/videos`);
+const handleOpenClips = () => openLink(`https://www.twitch.tv/${encodeURIComponent(currentChannelName)}/clips?filter=clips&range=7d`);
 const handleGoToCategory = () => {
     const formattedCategory = encodeURIComponent(currentCategoryName.toLowerCase().replace(/\s/g, '-'));
     openLink(`https://www.twitch.tv/directory/category/${formattedCategory}`);


### PR DESCRIPTION
Harden auth flow, permissions, and DOM handling (audit S1, S3, S4, B6).

### What & why
- `host_permissions` missing → fetches rely on CORS luck.
- Token parsing via `split('#')[1].split('=')[1]…` brittle.
- Two `onMessage` + two `onAlarm` listeners + async `return true` mismatch; `sendMessage({popup-auth-success})` from SW with closed popup throws unhandled.
- `innerHTML = channelName` etc + `href=…search?term=${term}` without encode → XSS.

### Touched areas
- `manifest.json:14` — add `host_permissions`
- `src/js/background.js:6,122` — merged listeners, guarded sendMessage, URLSearchParams parse
- `src/js/main.js:47,168,241,273,402,497` — `textContent`, `encodeURIComponent` for channel/category/search/player URLs, timed alert

### Testing
- [x] manifest valid, zip ok
- [ ] Manual: OAuth flow, search with `<script>` does not inject, context-menu Links encode correctly, badge still updates
- [x] CI green expected

---
Built with muse-spark-1.2-contributor-free in the OpenCode harness.