### PR TITLE
fix(perf): debounce search and make intervals idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `host_permissions` for `https://api.twitch.tv/*` and `https://id.twitch.tv/*` (S1)
 
+### Changed
+
+- Debounce search input (150ms) and make auto-refresh interval idempotent to prevent duplicate 30s polls and per-keystroke fetches (P1)
+- Eliminate storage write loop in settings sync by updating DOM directly on `storage.onChanged` (P2)
+- Make background alarm recreation use promise API (`clear`/`create`) instead of callback soup (P4)
+- Make periodic badge update await fresh fetch before updating badge (P3)
+
 ## [1.3.3] - 2024-02-22
 
 ### Enhancements

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -37,25 +37,9 @@ chrome.alarms.onAlarm.addListener((alarm) => {
     }
 });
 
-const createUpdateStreamsAlarm = (updateRateMin) => {
-    chrome.alarms.get("updateStreamsAlarm", (alarm) => {
-        // console.log(`[debug] creating background refresh alarm:`)
-        // console.log("  - before clear: updateStreamsAlarm get: ", alarm);
-    });
-
-    chrome.alarms.clear("updateStreamsAlarm", (wasCleared) => {
-        // console.log("    | updateStreamsAlarm wasCleared: ", wasCleared);
-    });
-
-    chrome.alarms.get("updateStreamsAlarm", (alarm) => {
-        // console.log("  - after clear: updateStreamsAlarm get: ", alarm);
-    });
-
-    chrome.alarms.create("updateStreamsAlarm", { periodInMinutes: updateRateMin });
-
-    chrome.alarms.get("updateStreamsAlarm", (alarm) => {
-        // console.log("[debug] new alarm: updateStreamsAlarm get: ", alarm);
-    });
+const createUpdateStreamsAlarm = async (updateRateMin) => {
+    await chrome.alarms.clear("updateStreamsAlarm");
+    await chrome.alarms.create("updateStreamsAlarm", { periodInMinutes: updateRateMin });
 };
 
 chrome.storage.local.get({ backgroundUpdateRateMin: 5 }, (data) => {
@@ -244,15 +228,7 @@ const getLiveTwitchStreams = async () => {
 };
 
 // Function to handle the periodic update of streams
-const updateStreamsPeriodically = () => {
-    // Refresh Twitch streams in the background
-    getLiveTwitchStreams();
-
-    // Update the badge count based on the latest data
-    chrome.storage.local.get("twitchStreams", (res) => {
-        if (res.twitchStreams) {
-            chrome.storage.local.set({ liveChannelsCount: res.twitchStreams.length });
-            updateBadge();
-        }
-    });
+const updateStreamsPeriodically = async () => {
+    await getLiveTwitchStreams();
+    await updateBadge();
 };

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,6 +1,8 @@
 const contentSection = document.getElementById("content");
 const filterInput = document.getElementById("searchStreams");
 const refreshButton = document.getElementById("refreshButton");
+let autoRefreshId = null;
+let searchDebounce = null;
 
 const authScreenPresent = () => {
     return contentSection.querySelector(".auth-header");
@@ -359,7 +361,10 @@ filterButtons.forEach(button => {
 });
 
 // Event listeners for the search input and refresh button
-filterInput.addEventListener("input", loadTwitchContent);
+filterInput.addEventListener("input", () => {
+    clearTimeout(searchDebounce);
+    searchDebounce = setTimeout(() => loadTwitchContent(), 150);
+});
 refreshButton.addEventListener("click", handleRefreshButtonClick);
 
 // Initial load
@@ -370,8 +375,9 @@ addEventListener("DOMContentLoaded", async () => {
 });
 
 const setupAutoRefresh = () => {
-    // Automatically refresh streams every minute (when popup is "open")
-    window.setInterval(async () => {
+    if (autoRefreshId) clearInterval(autoRefreshId);
+    // Automatically refresh streams every 30s while popup is open
+    autoRefreshId = window.setInterval(async () => {
         await loadTwitchContent();
     }, 1000 * 30);
 

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -85,18 +85,23 @@ document.getElementById("showRaidButtonToggle").addEventListener("change", funct
 });
 
 // Listen for changes in storage and update the toggle switches accordingly
+// (update DOM directly to avoid triggering another storage write loop)
 chrome.storage.onChanged.addListener((changes) => {
     if (changes.openInPlayerToggle !== undefined) {
-        setToggleSwitchStatus("openInPlayerToggle", changes.openInPlayerToggle.newValue);
+        const el = document.getElementById("openInPlayerToggle");
+        if (el) el.checked = changes.openInPlayerToggle.newValue;
     }
     if (changes.openInNewWindowToggle !== undefined) {
-        setToggleSwitchStatus("openInNewWindowToggle", changes.openInNewWindowToggle.newValue);
+        const el = document.getElementById("openInNewWindowToggle");
+        if (el) el.checked = changes.openInNewWindowToggle.newValue;
     }
     if (changes.showRaidButtonToggle !== undefined) {
-        setToggleSwitchStatus("showRaidButtonToggle", changes.showRaidButtonToggle.newValue);
+        const el = document.getElementById("showRaidButtonToggle");
+        if (el) el.checked = changes.showRaidButtonToggle.newValue;
     }
     if (changes.simpleViewToggle !== undefined) {
-        setToggleSwitchStatus("simpleViewToggle", changes.simpleViewToggle.newValue);
+        const el = document.getElementById("simpleViewToggle");
+        if (el) el.checked = changes.simpleViewToggle.newValue;
     }
     if (changes.backgroundUpdateRateMin !== undefined) {
         backgroundRefreshSelect.value = changes.backgroundUpdateRateMin.newValue;


### PR DESCRIPTION
Debounce, storage loop, alarm & badge race fixes (audit P1, P2, P3, P4).

### What & why
- Search input fired fetch per keystroke; autoRefresh duplicated interval → 2 fetches per 30s.
- Settings sync wrote storage → onChanged wrote again → loop.
- Badge count raced stale cache before fetch.
- Alarm recreation used 4 callbacks for debugging.

### Touched areas
- `src/js/main.js:2,363` — debounce 150ms, guard `autoRefreshId`
- `src/js/settings.js:88` — DOM direct update, no re-write
- `src/js/background.js:40,230` — promise alarm, await fetch→badge
- `CHANGELOG.md` — Unreleased Changed section

### Testing
- [x] manifest valid, zip ok
- [ ] Manual: type fast → only one reload after 150ms, open popup twice → single interval (check console), toggle settings → no loop
- [x] CI green expected

---
Built with muse-spark-1.2-contributor-free in the OpenCode harness.