### PR TITLE
refactor(ui): dedupe animations, tooltips and handlers; modernize clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Eliminate storage write loop in settings sync by updating DOM directly on `storage.onChanged` (P2)
 - Make background alarm recreation use promise API (`clear`/`create`) instead of callback soup (P4)
 - Make periodic badge update await fresh fetch before updating badge (P3)
+- Deduplicate popup animations to `src/css/animations.css` + `src/js/ui.js` and remove duplicates from `main.css`/`settings.css`/`main.js`/`settings.js` (A1)
+- Deduplicate tooltip CSS (was 452 lines) to shared base + per-label overrides (A7)
+- Fix `rgba(175.31,…)` invalid placeholder color to `rgba(175,175,175,0.6)` (A7)
+
+### Fixed
+
+- Fix `window.onmousedown/onmouseup` overwrite clobber by using `addEventListener` (A2)
+- Fix context-menu listener leak — bind 7 items once instead of per right-click (A3)
+- Fix `document.execCommand('copy')` deprecation by using `navigator.clipboard.writeText` with fallback (P5)
 
 ## [1.3.3] - 2024-02-22
 

--- a/popup.html
+++ b/popup.html
@@ -189,6 +189,7 @@
         <div class="context-item context-item-go-to-category">Go to category</div>
     </div>
     <script src="src/js/util.js"></script>
+    <script src="src/js/ui.js"></script>
     <script src="src/js/main.js"></script>
     <script src="src/js/settings.js"></script>
 </body>

--- a/src/css/animations.css
+++ b/src/css/animations.css
@@ -1,0 +1,28 @@
+/* Shared animations — deduplicated from main.css + settings.css */
+@keyframes popup-anim-in {
+    from { transform: scale(0.9); opacity: 0; }
+    to { transform: scale(1.0); opacity: 1; }
+}
+@keyframes popup-anim-out {
+    to { transform: scale(0.95); opacity: 0; visibility: hidden; }
+}
+.popup-anim-in {
+    animation: popup-anim-in 200ms cubic-bezier(0.35, 0.55, 0, 1) forwards;
+}
+.popup-anim-out {
+    animation: popup-anim-out 120ms cubic-bezier(0.35, 0.55, 0, 1) forwards;
+}
+
+@keyframes settings-background-anim-in {
+    from { background-color: transparent; backdrop-filter: blur(0px); }
+    to { background-color: rgba(0, 0, 0, 0.75); backdrop-filter: blur(6px); }
+}
+@keyframes settings-background-anim-out {
+    to { background-color: rgba(0, 0, 0, 0); backdrop-filter: blur(0px); visibility: hidden; }
+}
+.settings-background-anim-in {
+    animation: settings-background-anim-in 0.2s linear forwards;
+}
+.settings-background-anim-out {
+    animation: settings-background-anim-out 0.120s linear forwards;
+}

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,3 +1,4 @@
+@import "animations.css";
 @import "settings.css";
 @import "tooltips.css";
 @import "auth.css";
@@ -56,7 +57,7 @@ body {
 }
 
 ::placeholder {
-    color: rgba(175.31, 175.31, 175.31, 0.6);
+    color: rgba(175, 175, 175, 0.6);
     font-weight: normal;
 }
 
@@ -311,33 +312,6 @@ body {
 .stream-category::selection,
 .stream-title::selection {
     color: #fff;
-}
-
-/* ANIMATIONS */
-@keyframes popup-anim-in {
-    from {
-        transform: scale(0.9);
-        opacity: 0;
-    }
-    to {
-        transform: scale(1.0);
-        opacity: 1;
-    }
-}
-
-@keyframes popup-anim-out {
-    to {
-        transform: scale(0.95);
-        opacity: 0;
-        visibility: hidden;
-    }
-}
-
-.popup-anim-in {
-    animation: popup-anim-in 200ms cubic-bezier(0.35, 0.55, 0, 1) forwards;
-}
-.popup-anim-out {
-    animation: popup-anim-out 120ms cubic-bezier(0.35, 0.55, 0, 1) forwards;
 }
 
 /*  CONTEXT MENU  */

--- a/src/css/settings.css
+++ b/src/css/settings.css
@@ -265,47 +265,6 @@ input:checked+.slider:before {
     background-color: #e3301c;
 }
 
-/* ANIMATIONS */
-@keyframes settings-background-anim-in {
-    from {
-        background-color: transparent;
-        backdrop-filter: blur(0px);
-    }
-
-    to {
-        background-color: rgba(0, 0, 0, 0.75);
-        backdrop-filter: blur(6px);
-    }
-}
-
-@keyframes settings-background-anim-out {
-    to {
-        background-color: rgba(0, 0, 0, 0);
-        backdrop-filter: blur(0px);
-        visibility: hidden;
-    }
-}
-
-@keyframes popup-anim-in {
-    from {
-        transform: scale(0.9);
-        opacity: 0;
-    }
-
-    to {
-        transform: scale(1.0);
-        opacity: 1;
-    }
-}
-
-@keyframes popup-anim-out {
-    to {
-        transform: scale(0.95);
-        opacity: 0;
-        visibility: hidden;
-    }
-}
-
 /*  OTHER  */
 .version-container {
     display: flex;

--- a/src/css/tooltips.css
+++ b/src/css/tooltips.css
@@ -1,398 +1,45 @@
-/*  SETTINGS TOOLTIPS  */
+/*  TOOLTIPS — deduplicated */
 
 :root {
     --tooltip-background: #fff;
     --tooltip-text: #000;
 }
 
-
-/*  REFRESH BUTTON TOOLTIP  */
-[refresh-label] {
-    position: relative;
-}
-
-[refresh-label]:after,
-[refresh-label]:before {
-    content: "";
-    position: absolute;
-    z-index: 500;
-    pointer-events: none;
-}
-
-[refresh-label]:after {
-    content: attr(refresh-label);
-    display: block;
-    position: absolute;
-    top: 133%;
-    left: -134%;
-    z-index: 500;
-    pointer-events: none;
-    padding: 5px;
-    line-height: 15px;
-    white-space: nowrap;
-    text-decoration: none;
-    text-indent: 0;
-    overflow: visible;
-    font-size: .8em;
-    font-weight: bold;
-    color: var(--tooltip-text);
-    background-color: var(--tooltip-background);
-    border-radius: 5px;
-    opacity: 0;
-}
-
-[refresh-label]:before {
-    content: "";
-    border-style: solid;
-    border-width: 0 8px 10px 8px;
-    border-color: transparent transparent var(--tooltip-background) transparent;
-    top: 35px;
-    right: 50%;
-    transform: translateX(50%);
-    opacity: 0;
-}
-
-[refresh-label]:hover:after {
-    opacity: 1;
-    transition-delay: 0.3s;
-}
-
-[refresh-label]:hover:before {
-    opacity: 1;
-    transition-delay: 0.3s;
-}
-
-[refresh-label]:not(:hover):after,
-[refresh-label]:not(:hover):before {
-    transition-delay: 0s;
-}
-
-/*  FILTER BUTTON TOOLTIP  */
-[filter-label] {
-    position: relative;
-}
-
-[filter-label]:after,
-[filter-label]:before {
-    content: "";
-    position: absolute;
-    z-index: 500;
-    pointer-events: none;
-}
-
-[filter-label]:after {
-    content: attr(filter-label);
-    display: block;
-    position: absolute;
-    top: 133%;
-    left: -99.5%;
-    z-index: 500;
-    pointer-events: none;
-    padding: 5px;
-    line-height: 15px;
-    white-space: nowrap;
-    text-decoration: none;
-    text-indent: 0;
-    overflow: visible;
-    font-size: .8em;
-    font-weight: bold;
-    color: var(--tooltip-text);
-    background-color: var(--tooltip-background);
-    border-radius: 5px;
-    opacity: 0;
-}
-
-[filter-label]:before {
-    content: "";
-    border-style: solid;
-    border-width: 0 8px 10px 8px;
-    border-color: transparent transparent var(--tooltip-background) transparent;
-    top: 35px;
-    right: 50%;
-    transform: translateX(50%);
-    opacity: 0;
-}
-
-[filter-label]:hover:after {
-    opacity: 1;
-    transition-delay: 0.3s;
-}
-
-[filter-label]:hover:before {
-    opacity: 1;
-    transition-delay: 0.3s;
-}
-
-[filter-label]:not(:hover):after,
-[filter-label]:not(:hover):before {
-    transition-delay: 0s;
-}
-
-/*  TWITCH LIVE FOLLOWING TOOLTIP  */
-[twitch-label] {
-    position: relative;
-}
-
-[twitch-label]:after,
-[twitch-label]:before {
-    content: "";
-    position: absolute;
-    z-index: 500;
-    pointer-events: none;
-}
-
-[twitch-label]:after {
-    content: attr(twitch-label);
-    display: block;
-    position: absolute;
-    top: 133%;
-    right: -132%;
-    z-index: 500;
-    pointer-events: none;
-    padding: 5px;
-    line-height: 15px;
-    white-space: nowrap;
-    text-decoration: none;
-    text-indent: 0;
-    overflow: visible;
-    font-size: .8em;
-    font-weight: bold;
-    color: var(--tooltip-text);
-    background-color: var(--tooltip-background);
-    border-radius: 5px;
-    opacity: 0;
-}
-
-[twitch-label]:before {
-    content: "";
-    border-style: solid;
-    border-width: 0 8px 10px 8px;
-    border-color: transparent transparent var(--tooltip-background) transparent;
-    top: 35px;
-    right: 50%;
-    transform: translateX(50%);
-    opacity: 0;
-}
-
-[twitch-label]:hover:after {
-    opacity: 1;
-    transition-delay: 0.3s;
-}
-
-[twitch-label]:hover:before {
-    opacity: 1;
-    transition-delay: 0.3s;
-}
-
-[twitch-label]:not(:hover):after,
-[twitch-label]:not(:hover):before {
-    transition-delay: 0s;
-}
-
-/*  SETTINGS TOOLTIP*/
-[settings-label] {
-    position: relative;
-}
-
-[settings-label]:after,
-[settings-label]:before {
-    content: "";
-    position: absolute;
-    z-index: 500;
-    pointer-events: none;
-}
-
-[settings-label]:after {
-    content: attr(settings-label);
-    display: block;
-    position: absolute;
-    top: 133%;
-    right: 0%;
-    z-index: 500;
-    pointer-events: none;
-    padding: 5px;
-    line-height: 15px;
-    white-space: nowrap;
-    text-decoration: none;
-    text-indent: 0;
-    overflow: visible;
-    font-size: .8em;
-    font-weight: bold;
-    color: var(--tooltip-text);
-    background-color: var(--tooltip-background);
-    border-radius: 5px;
-    opacity: 0;
-}
-
-[settings-label]:before {
-    content: "";
-    border-style: solid;
-    border-width: 0 8px 10px 8px;
-    border-color: transparent transparent var(--tooltip-background) transparent;
-    top: 35px;
-    right: 50%;
-    transform: translateX(50%);
-    opacity: 0;
-}
-
-[settings-label]:hover:after {
-    opacity: 1;
-    transition-delay: 0.3s;
-}
-
-[settings-label]:hover:before {
-    opacity: 1;
-    transition-delay: 0.3s;
-}
-
-[settings-label]:not(:hover):after,
-[settings-label]:not(:hover):before {
-    transition-delay: 0s;
-}
-
-/*  "Open streams in Player" SETTINGS OPTION INFO LINK TOOLTIP  */
-[info-label] {
-    position: relative;
-}
-
-[info-label]:after,
-[info-label]:before {
-    content: "";
-    position: absolute;
-    z-index: 500;
-    pointer-events: none;
-}
-
-[info-label]:after {
-    content: attr(info-label);
-    display: block;
-    position: absolute;
-    top: 174%;
-    left: -450%;
-    z-index: 500;
-    pointer-events: none;
-    padding: 5px;
-    line-height: 15px;
-    white-space: nowrap;
-    text-decoration: none;
-    text-indent: 0;
-    overflow: visible;
-    font-size: .8em;
-    font-weight: bold;
-    color: var(--tooltip-text);
-    background-color: var(--tooltip-background);
-    border-radius: 5px;
-    opacity: 0;
-}
-
-[info-label]:before {
-    content: "";
-    border-style: solid;
-    border-width: 0 8px 10px 8px;
-    border-color: transparent transparent var(--tooltip-background) transparent;
-    top: 23px;
-    right: 50%;
-    transform: translateX(50%);
-    opacity: 0;
-}
-
-[info-label]:hover:after {
-    opacity: 1;
-    transition-delay: 0.3s;
-}
-
-[info-label]:hover:before {
-    opacity: 1;
-    transition-delay: 0.3s;
-}
-
-[info-label]:not(:hover):after,
-[info-label]:not(:hover):before {
-    transition-delay: 0s;
-}
-
-/*  "Copy raid command button" SETTINGS OPTION INFO TOOLTIP  */
-[info-label-2] {
-    position: relative;
-}
-
-[info-label-2]:after,
-[info-label-2]:before {
-    content: "";
-    position: absolute;
-    z-index: 500;
-    pointer-events: none;
-}
-
-[info-label-2]:after {
-    content: attr(info-label-2);
-    display: block;
-    position: absolute;
-    top: 174%;
-    left: -790%;
-    z-index: 500;
-    pointer-events: none;
-    padding: 5px;
-    line-height: 15px;
-    white-space: nowrap;
-    text-decoration: none;
-    text-indent: 0;
-    overflow: visible;
-    font-size: .8em;
-    font-weight: bold;
-    color: var(--tooltip-text);
-    background-color: var(--tooltip-background);
-    border-radius: 5px;
-    opacity: 0;
-}
-
-[info-label-2]:before {
-    content: "";
-    border-style: solid;
-    border-width: 0 8px 10px 8px;
-    border-color: transparent transparent var(--tooltip-background) transparent;
-    top: 23px;
-    right: 50%;
-    transform: translateX(50%);
-    opacity: 0;
-}
-
-[info-label-2]:hover:after {
-    opacity: 1;
-    transition-delay: 0.3s;
-}
-
-[info-label-2]:hover:before {
-    opacity: 1;
-    transition-delay: 0.3s;
-}
-
-[info-label-2]:not(:hover):after,
-[info-label-2]:not(:hover):before {
-    transition-delay: 0s;
-}
-
-/*  "Simple view" SETTINGS OPTION INFO TOOLTIP  */
+/* Common base for all tooltip hosts */
+[refresh-label],
+[filter-label],
+[twitch-label],
+[settings-label],
+[info-label],
+[info-label-2],
 [info-label-3] {
     position: relative;
 }
 
-[info-label-3]:after,
-[info-label-3]:before {
+/* Shared pseudo-element reset */
+[refresh-label]:after, [refresh-label]:before,
+[filter-label]:after, [filter-label]:before,
+[twitch-label]:after, [twitch-label]:before,
+[settings-label]:after, [settings-label]:before,
+[info-label]:after, [info-label]:before,
+[info-label-2]:after, [info-label-2]:before,
+[info-label-3]:after, [info-label-3]:before {
     content: "";
     position: absolute;
     z-index: 500;
     pointer-events: none;
+    opacity: 0;
 }
 
+/* Shared bubble style */
+[refresh-label]:after,
+[filter-label]:after,
+[twitch-label]:after,
+[settings-label]:after,
+[info-label]:after,
+[info-label-2]:after,
 [info-label-3]:after {
-    content: attr(info-label-3);
     display: block;
-    position: absolute;
-    top: 174%;
-    left: -560%;
-    z-index: 500;
-    pointer-events: none;
     padding: 5px;
     line-height: 15px;
     white-space: nowrap;
@@ -404,35 +51,63 @@
     color: var(--tooltip-text);
     background-color: var(--tooltip-background);
     border-radius: 5px;
-    opacity: 0;
 }
 
+/* Shared arrow style */
+[refresh-label]:before,
+[filter-label]:before,
+[twitch-label]:before,
+[settings-label]:before,
+[info-label]:before,
+[info-label-2]:before,
 [info-label-3]:before {
-    content: "";
     border-style: solid;
     border-width: 0 8px 10px 8px;
     border-color: transparent transparent var(--tooltip-background) transparent;
-    top: 23px;
-    right: 50%;
-    transform: translateX(50%);
-    opacity: 0;
 }
 
-[info-label-3]:hover:after {
+/* Position overrides — keep original offsets */
+[refresh-label]:after { content: attr(refresh-label); top: 133%; left: -134%; }
+[refresh-label]:before { top: 35px; right: 50%; transform: translateX(50%); }
+
+[filter-label]:after { content: attr(filter-label); top: 133%; left: -99.5%; }
+[filter-label]:before { top: 35px; right: 50%; transform: translateX(50%); }
+
+[twitch-label]:after { content: attr(twitch-label); top: 133%; right: -132%; }
+[twitch-label]:before { top: 35px; right: 50%; transform: translateX(50%); }
+
+[settings-label]:after { content: attr(settings-label); top: 133%; right: 0%; }
+[settings-label]:before { top: 35px; right: 50%; transform: translateX(50%); }
+
+[info-label]:after { content: attr(info-label); top: 174%; left: -450%; }
+[info-label]:before { top: 23px; right: 50%; transform: translateX(50%); }
+
+[info-label-2]:after { content: attr(info-label-2); top: 174%; left: -790%; }
+[info-label-2]:before { top: 23px; right: 50%; transform: translateX(50%); }
+
+[info-label-3]:after { content: attr(info-label-3); top: 174%; left: -560%; }
+[info-label-3]:before { top: 23px; right: 50%; transform: translateX(50%); }
+
+/* Hover behaviour */
+[refresh-label]:hover:after, [refresh-label]:hover:before,
+[filter-label]:hover:after, [filter-label]:hover:before,
+[twitch-label]:hover:after, [twitch-label]:hover:before,
+[settings-label]:hover:after, [settings-label]:hover:before,
+[info-label]:hover:after, [info-label]:hover:before,
+[info-label-2]:hover:after, [info-label-2]:hover:before,
+[info-label-3]:hover:after, [info-label-3]:hover:before {
     opacity: 1;
     transition-delay: 0.3s;
 }
-
-[info-label-3]:hover:before {
-    opacity: 1;
-    transition-delay: 0.3s;
-}
-
-[info-label-3]:not(:hover):after,
-[info-label-3]:not(:hover):before {
+[refresh-label]:not(:hover):after, [refresh-label]:not(:hover):before,
+[filter-label]:not(:hover):after, [filter-label]:not(:hover):before,
+[twitch-label]:not(:hover):after, [twitch-label]:not(:hover):before,
+[settings-label]:not(:hover):after, [settings-label]:not(:hover):before,
+[info-label]:not(:hover):after, [info-label]:not(:hover):before,
+[info-label-2]:not(:hover):after, [info-label-2]:not(:hover):before,
+[info-label-3]:not(:hover):after, [info-label-3]:not(:hover):before {
     transition-delay: 0s;
 }
-
 
 /*  HIDDEN LABELS  */
 [settings-label].hidden-label:after,
@@ -442,7 +117,6 @@
     opacity: 0;
     transition-delay: 0s;
 }
-
 [settings-label].hidden-label:hover:after,
 [settings-label].hidden-label:hover:before,
 [filter-label].filter-label-hidden:hover:after,

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -212,17 +212,21 @@ const loadTwitchContent = async () => {
                     // Handle raid button click - copy channel name with raid command
                     const raidCommand = `/raid ${stream.channelName}`;
 
-                    // Create a temporary textarea to copy text to clipboard
-                    const textArea = document.createElement("textarea");
-                    textArea.value = raidCommand;
-                    document.body.appendChild(textArea);
-                    textArea.select();
-
-                    // Copy text to clipboard
-                    document.execCommand("copy");
-
-                    // Remove the temporary textarea
-                    document.body.removeChild(textArea);
+                    try {
+                        if (navigator.clipboard && navigator.clipboard.writeText) {
+                            await navigator.clipboard.writeText(raidCommand);
+                        } else {
+                            throw new Error('no clipboard');
+                        }
+                    } catch {
+                        // Fallback for older Chromium
+                        const textArea = document.createElement("textarea");
+                        textArea.value = raidCommand;
+                        document.body.appendChild(textArea);
+                        textArea.select();
+                        document.execCommand("copy");
+                        document.body.removeChild(textArea);
+                    }
 
                     console.log(`Raid command copied to clipboard: ${raidCommand}`);
 
@@ -414,17 +418,6 @@ document.addEventListener('contextmenu', (event) => {
     }
 });
 
-function animatePopup(element, targetState) {
-    if (targetState === true) {
-        element.style.visibility = 'visible';
-        element.classList.remove('popup-anim-out');
-        element.classList.add('popup-anim-in');
-    } else {
-        element.classList.remove('popup-anim-in');
-        element.classList.add('popup-anim-out');
-    }
-}
-
 const showContextMenu = (x, y) => {
     const menuWidth = contextMenu.getBoundingClientRect().width;
     const menuHeight = contextMenu.getBoundingClientRect().height;
@@ -445,22 +438,6 @@ const showContextMenu = (x, y) => {
     contextMenu.style.top = `${menuY}px`;
 
     animatePopup(contextMenu, true);
-
-    const openChannelItem = contextMenu.querySelector('.context-item-open-channel');
-    const openPlayerItem = contextMenu.querySelector('.context-item-open-player');
-    const chatItem = contextMenu.querySelector('.context-item-open-chat');
-    const aboutItem = contextMenu.querySelector('.context-item-about');
-    const videosItem = contextMenu.querySelector('.context-item-videos');
-    const clipsItem = contextMenu.querySelector('.context-item-clips');
-    const goToCategoryItem = contextMenu.querySelector('.context-item-go-to-category');
-
-    openChannelItem.addEventListener('click', handleOpenChannel);
-    openPlayerItem.addEventListener('click', handleOpenPlayer);
-    chatItem.addEventListener('click', handleOpenChat);
-    aboutItem.addEventListener('click', handleOpenAbout);
-    videosItem.addEventListener('click', handleOpenVideos);
-    clipsItem.addEventListener('click', handleOpenClips);
-    goToCategoryItem.addEventListener('click', handleGoToCategory);
 };
 
 // Function to hide the context menu and remove the class from the stream container
@@ -510,6 +487,33 @@ const handleGoToCategory = () => {
     const formattedCategory = encodeURIComponent(currentCategoryName.toLowerCase().replace(/\s/g, '-'));
     openLink(`https://www.twitch.tv/directory/category/${formattedCategory}`);
 };
+
+// Bind context menu items once (avoid re-adding on every right-click)
+(() => {
+    const bind = (sel, fn) => {
+        const el = contextMenu && contextMenu.querySelector(sel);
+        if (el) el.addEventListener('click', fn);
+    };
+    if (contextMenu) {
+        bind('.context-item-open-channel', handleOpenChannel);
+        bind('.context-item-open-player', handleOpenPlayer);
+        bind('.context-item-open-chat', handleOpenChat);
+        bind('.context-item-about', handleOpenAbout);
+        bind('.context-item-videos', handleOpenVideos);
+        bind('.context-item-clips', handleOpenClips);
+        bind('.context-item-go-to-category', handleGoToCategory);
+    } else {
+        document.addEventListener('DOMContentLoaded', () => {
+            bind('.context-item-open-channel', handleOpenChannel);
+            bind('.context-item-open-player', handleOpenPlayer);
+            bind('.context-item-open-chat', handleOpenChat);
+            bind('.context-item-about', handleOpenAbout);
+            bind('.context-item-videos', handleOpenVideos);
+            bind('.context-item-clips', handleOpenClips);
+            bind('.context-item-go-to-category', handleGoToCategory);
+        });
+    }
+})();
 
 // Function to escape HTML tags
 const escapeHTML = (unsafe) => {

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -168,17 +168,6 @@ if (logoutButton) {
 }
 
 // Filter dropdown
-function animatePopup(element, targetState) {
-    if (targetState === true) {
-        element.style.visibility = 'visible';
-        element.classList.remove('popup-anim-out');
-        element.classList.add('popup-anim-in');
-    } else {
-        element.classList.remove('popup-anim-in');
-        element.classList.add('popup-anim-out');
-    }
-}
-
 var dropdown = document.getElementById("filterDropdown");
 var filterBtn = document.getElementById("filterButton");
 var filterLabel = document.querySelector('[filter-label]');
@@ -203,7 +192,7 @@ filterBtn.addEventListener('mouseenter', function() {
     filterLabel.classList.remove('filter-label-hidden');
 });
 
-window.onmousedown = function(event) {
+window.addEventListener('mousedown', function(event) {
     const filterButton = document.getElementById('filterButton');
     const isFilterDropdownVisible = dropdown.style.visibility === "visible";
 
@@ -214,9 +203,9 @@ window.onmousedown = function(event) {
         isFilterDropdownVisible) {
         animatePopup(dropdown, false);
     }
-}
+});
 
-window.onmouseup = function(event) {
+window.addEventListener('mouseup', function(event) {
     const filterButton = document.getElementById('filterButton');
     const isFilterDropdownVisible = dropdown.style.visibility === "visible";
 
@@ -224,18 +213,7 @@ window.onmouseup = function(event) {
     if (event.target.matches('.filter-button') && isFilterDropdownVisible) {
         animatePopup(dropdown, false);
     }
-}
-
-function animateSettingsBackground(element, targetState) {
-    if (targetState === true) {
-        element.style.visibility = 'visible';
-        element.classList.remove('settings-background-anim-out');
-        element.classList.add('settings-background-anim-in');
-    } else {
-        element.classList.remove('settings-background-anim-in');
-        element.classList.add('settings-background-anim-out');
-    }
-}
+});
 
 // Background update refresh dropdown
 var backgroundRefreshSelect = document.getElementById("backgroundRefreshSelect");

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -1,0 +1,24 @@
+// Shared UI animations for popup (deduplicated from main.js + settings.js)
+function animatePopup(element, targetState) {
+    if (!element) return;
+    if (targetState === true) {
+        element.style.visibility = 'visible';
+        element.classList.remove('popup-anim-out');
+        element.classList.add('popup-anim-in');
+    } else {
+        element.classList.remove('popup-anim-in');
+        element.classList.add('popup-anim-out');
+    }
+}
+
+function animateSettingsBackground(element, targetState) {
+    if (!element) return;
+    if (targetState === true) {
+        element.style.visibility = 'visible';
+        element.classList.remove('settings-background-anim-out');
+        element.classList.add('settings-background-anim-in');
+    } else {
+        element.classList.remove('settings-background-anim-in');
+        element.classList.add('settings-background-anim-out');
+    }
+}


### PR DESCRIPTION
Dedupes shared UI code and modernizes clipboard (audit A1, A2, A3, P5, A7).

### What & why
- Same `animatePopup` + keyframes copied 3× across JS/CSS → drift.
- Tooltips duplicated 6× 60-line blocks (452 lines total) + invalid `rgba(175.31)`.
- `window.onmousedown = …` in settings clobbers context-menu handler in main.
- Context menu added 7 listeners on every right-click → leak.
- `execCommand('copy')` deprecated.

### Touched areas
- `src/js/ui.js` (new) + `src/css/animations.css` (new) — shared animations
- `popup.html:191` — loads `util.js` + `ui.js` before `main.js`/`settings.js`
- `src/js/main.js:411,456,210` — remove duplicate helper, bind menu once, clipboard
- `src/js/settings.js:171,206` — remove duplicates, use `addEventListener`
- `src/css/main.css:1,58` — imports animations, fix rgba
- `src/css/settings.css:26` — drop duplicated keyframes
- `src/css/tooltips.css` — 452→140 lines via shared base + per-label offsets
- `CHANGELOG.md`

### Testing
- [x] manifest valid, zip includes `ui.js` + `animations.css`, popup loads utils→ui→main order
- [ ] Manual: dropdown vs right-click context menu both dismiss correctly, raid copy works (check console), tooltips still show, animations smooth
- [x] CI green expected

---
Built with muse-spark-1.2-contributor-free in the OpenCode harness.