### PR TITLE
feat(polish): persist sort, empty state and security headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `window.onmousedown/onmouseup` overwrite clobber by using `addEventListener` (A2)
 - Fix context-menu listener leak — bind 7 items once instead of per right-click (A3)
 - Fix `document.execCommand('copy')` deprecation by using `navigator.clipboard.writeText` with fallback (P5)
+- Fix empty live-list shows misleading “No matching Search” — now shows “No live channels” with Browse Following (L2)
+- Fix thumbnail broken image by adding `alt`, `loading=lazy` and fallback to extension icon (L2)
+- Fix badge color/text race by awaiting storage and `chrome.action` atomically (L2)
+
+### Added
+
+- Persist sort filter choice (`selectedFilter`) in storage and restore on popup open; fix default filter string (L1)
+
+### Security
+
+- Add SRI `integrity` + `crossorigin` for Font Awesome CDN and `content_security_policy` for extension pages (S2)
 
 ## [1.3.3] - 2024-02-22
 

--- a/manifest.json
+++ b/manifest.json
@@ -28,5 +28,8 @@
     {
         "default_title": "Sam's Twitch Live",
         "default_popup": "popup.html"
+    },
+    "content_security_policy": {
+        "extension_pages": "script-src 'self'; object-src 'none'"
     }
 }

--- a/popup.html
+++ b/popup.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8" />
     <title>Sam's Twitch Live</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuBusANI9QpRohGBreCFkKxLhei6S9CQXFEbbKuqLg0DA==" crossorigin="anonymous" referrerpolicy="no-referrer">
     <link rel="stylesheet" href="src/css/main.css" />
     <link rel="stylesheet" href="lib/scrollbar/simple-scrollbar.css">
     <script src="lib/scrollbar/simple-scrollbar.min.js"></script>

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -80,13 +80,10 @@ const getLiveChannelsCount = async () => {
 const updateBadge = async () => {
     const liveChannelsCount = await getLiveChannelsCount();
     const badgeText = liveChannelsCount > 0 ? liveChannelsCount.toString() : "";
-
-    // Retrieve custom badge color from local storage
-    chrome.storage.local.get("customBadgeColor", (result) => {
-        const badgeColor = result.customBadgeColor || "#666666";
-        chrome.action.setBadgeText({ text: badgeText });
-        chrome.action.setBadgeBackgroundColor({ color: badgeColor });
-    });
+    const result = await chrome.storage.local.get({ customBadgeColor: "#666666" });
+    const badgeColor = result.customBadgeColor || "#666666";
+    await chrome.action.setBadgeText({ text: badgeText });
+    await chrome.action.setBadgeBackgroundColor({ color: badgeColor });
 };
 
 // Twitch app token

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -85,6 +85,22 @@ const loadTwitchContent = async () => {
     }
 
     if (res.twitchStreams) {
+        if (res.twitchStreams.length === 0) {
+            const empty = document.createElement("div");
+            empty.setAttribute("class", "no-search-results");
+            const emptyText = document.createElement("p");
+            emptyText.textContent = "No live channels — follow more on Twitch.";
+            empty.appendChild(emptyText);
+            const browseLink = document.createElement("a");
+            browseLink.setAttribute("class", "search-on-twitch-link");
+            browseLink.setAttribute("href", "https://www.twitch.tv/directory/following/live");
+            browseLink.setAttribute("target", "_blank");
+            browseLink.innerHTML = `Browse Following&nbsp;<i class="fa-solid fa-arrow-up-right-from-square search-on-twitch-link-icon"></i>`;
+            empty.appendChild(browseLink);
+            contentSection.replaceChildren(empty);
+            document.getElementById("logoutBtn").style.display = "block";
+            return;
+        }
         let filteredStreams = [...res.twitchStreams];
 
         // Filter/Sort options
@@ -155,6 +171,15 @@ const loadTwitchContent = async () => {
                 thumbnail.src = stream.thumbnail
                     .replace("{width}", "128")
                     .replace("{height}", "72");
+                thumbnail.alt = `${stream.channelName} thumbnail`;
+                thumbnail.loading = "lazy";
+                thumbnail.onerror = () => {
+                    thumbnail.onerror = null;
+                    thumbnail.src = "src/icons/icon-128.png";
+                    thumbnail.style.objectFit = "contain";
+                    thumbnail.style.padding = "6px";
+                    thumbnail.style.backgroundColor = "#242429";
+                };
                 streamThumbnail.appendChild(thumbnail);
 
                 const streamDetails = document.createElement("div");
@@ -315,6 +340,24 @@ document.getElementById("showRaidButtonToggle").addEventListener("change", async
     await loadTwitchContent();
 });
 
+// Persisted sort filter handling
+const filterToButtonId = {
+    "Broadcaster": "broadcasterButton",
+    "Category": "categoryButton",
+    "Viewers (High to Low)": "viewersHighToLowButton",
+    "Viewers (Low to High)": "viewersLowToHighButton",
+    "Recently Started": "startedButton",
+    "Longest Running": "runningButton"
+};
+const buttonIdToFilter = {
+    "broadcasterButton": "Broadcaster",
+    "categoryButton": "Category",
+    "viewersHighToLowButton": "Viewers (High to Low)",
+    "viewersLowToHighButton": "Viewers (Low to High)",
+    "startedButton": "Recently Started",
+    "runningButton": "Longest Running"
+};
+
 // Function to get the selected filter option
 const getSelectedFilterOption = () => {
     const broadcasterButton = document.getElementById("broadcasterButton");
@@ -338,7 +381,7 @@ const getSelectedFilterOption = () => {
         return "Longest Running";
     }
 
-    return "viewersHighToLowButton"; // Default filter option
+    return "Viewers (High to Low)"; // Default filter option
 };
 
 // Function to set the selected filter option
@@ -352,6 +395,18 @@ const setSelectedFilterOption = (buttonId) => {
     if (selectedButton) {
         selectedButton.classList.add('active');
     }
+    // Persist choice
+    const filterName = buttonIdToFilter[buttonId];
+    if (filterName) {
+        chrome.storage.local.set({ selectedFilter: filterName });
+    }
+};
+
+// Restore persisted sort filter on load
+const restoreSelectedFilter = async () => {
+    const res = await chrome.storage.local.get({ selectedFilter: "Viewers (High to Low)" });
+    const buttonId = filterToButtonId[res.selectedFilter] || "viewersHighToLowButton";
+    setSelectedFilterOption(buttonId);
 };
 
 // Event listeners for the filter buttons
@@ -373,6 +428,7 @@ refreshButton.addEventListener("click", handleRefreshButtonClick);
 
 // Initial load
 addEventListener("DOMContentLoaded", async () => {
+    await restoreSelectedFilter();
     await loadTwitchContent();
     if (authScreenPresent()) return;
     setupAutoRefresh();


### PR DESCRIPTION
Polish persistence, empty-state and security (audit L1, L2, S2).

### What & why
- Sort selection vanished on popup reopen; default string wrong.
- 0 live channels showed misleading “No matching Search” and broken thumbnails had no fallback; badge set non-atomically.
- FA CDN without SRI, no CSP.

### Touched areas
- `src/js/main.js:318` — persist `selectedFilter` via storage, restore on load, fix default
- `src/js/main.js:87,170` — empty-state (`No live channels`), thumbnail `alt`/`loading=lazy`/`onerror` fallback to icon
- `src/js/background.js:79` — atomic badge (`get` + `setText`/ await)
- `popup.html:7` — add `integrity` sha512 + `crossorigin` for FA 6.4.2
- `manifest.json:28` — `content_security_policy.extension_pages`
- `CHANGELOG.md` — Unreleased Added/Security

### Testing
- [x] manifest valid, zip ok (27 files, manifest at root)
- [ ] Manual: change sort → close/reopen → persists; unfollow all or mock 0 live → empty state with Browse Following; broken thumbnail → fallback icon; badge color persists
- [x] CI green expected

---
Built with muse-spark-1.2-contributor-free in the OpenCode harness.