### PR TITLE
style(pages): polish landing page layout, header and footer

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -44,11 +44,19 @@
             </div>
         </div>
     </div>
-    <div class="footer">
-        <a href="https://github.com/yungsamd17/Twitch-Live" target="_blank" rel="noopener">Source Code</a>
-        <a href="https://github.com/yungsamd17/Twitch-Live/issues" target="_blank" rel="noopener">Bugs &amp; Suggestions</a>
-        <a href="https://github.com/yungsamd17/Twitch-Live/releases" target="_blank" rel="noopener">Release Notes</a>
-    </div>
+    <footer class="footer">
+        <div class="footer-inner">
+            <p class="footer-brand">© 2024–<span id="currentYear">2026</span> <a href="https://yungsamd17.github.io" target="_blank" rel="noopener">yungsamd17</a></p>
+            <nav class="footer-links" aria-label="Footer">
+                <a href="https://github.com/yungsamd17/Twitch-Live" target="_blank" rel="noopener"><i class="fa-solid fa-code" aria-hidden="true"></i><span>Source Code</span></a>
+                <a href="https://github.com/yungsamd17/Twitch-Live/issues" target="_blank" rel="noopener"><i class="fa-solid fa-bug" aria-hidden="true"></i><span>Bugs &amp; Suggestions</span></a>
+                <a href="https://github.com/yungsamd17/Twitch-Live/releases" target="_blank" rel="noopener"><i class="fa-solid fa-tag" aria-hidden="true"></i><span>Release Notes</span></a>
+            </nav>
+        </div>
+    </footer>
+    <script>
+        document.getElementById('currentYear').textContent = new Date().getFullYear();
+    </script>
 </body>
 
 </html>

--- a/website/index.html
+++ b/website/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <meta charset="UTF-8" />
@@ -26,25 +26,25 @@
         <div class="wrapper">
             <div class="content">
                 <div>
-                    <span class="header">Sam's Twitch 
-                    	<span class="accent-color">Live</span>
-                    </span>
-                    <p>Your ultimate companion for staying connected<br>with your favorite Twitch streams.</p>
+                    <h1 class="header">Sam's Twitch
+                        <span class="accent-color">Live</span>
+                    </h1>
+                    <p>Your ultimate companion for staying connected with your favorite Twitch streams.</p>
                     <div class="install-button-container">
                         <a href="https://chromewebstore.google.com/detail/sams-twitch-live/fnaolpkjdickppbebcafdajjndmkgbei" class="install-button">
-                            <i class="fa-brands fa-chrome"></i> Install from Chrome Web Store</a>
+                            <i class="fa-brands fa-chrome" aria-hidden="true"></i> Install from Chrome Web Store</a>
                     </div>
                 </div>
             </div>
             <div class="previewImage">
-                <img src="assets/preview.png">
+                <img src="assets/preview.png" alt="Preview of Sam's Twitch Live extension popup" width="430" height="600" loading="eager">
             </div>
         </div>
     </div>
     <div class="footer">
-        <a href="https://github.com/yungsamd17/Twitch-Live" target="_blank">Source Code</a>
-        <a href="https://github.com/yungsamd17/Twitch-Live/issues" target="_blank">Bugs & Suggestions</a>
-        <a href="https://github.com/yungsamd17/Twitch-Live/releases" target="_blank">Release Notes</a>
+        <a href="https://github.com/yungsamd17/Twitch-Live" target="_blank" rel="noopener">Source Code</a>
+        <a href="https://github.com/yungsamd17/Twitch-Live/issues" target="_blank" rel="noopener">Bugs &amp; Suggestions</a>
+        <a href="https://github.com/yungsamd17/Twitch-Live/releases" target="_blank" rel="noopener">Release Notes</a>
     </div>
 </body>
 

--- a/website/index.html
+++ b/website/index.html
@@ -16,6 +16,9 @@
     <meta name="twitter:image" content="https://yungsamd17.github.io/Twitch-Live/assets/link-preview.png">
     <link rel="stylesheet" href="style.css">
     <link rel="icon" href="assets/favicon.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Archivo:wght@800&display=swap">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
     <script data-goatcounter="https://yungsamd17.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
     <!--<script type="text/javascript" src="https://livejs.com/live.js"></script>-->

--- a/website/style.css
+++ b/website/style.css
@@ -76,7 +76,7 @@ body::-webkit-scrollbar {
 
 .header {
     font-size: clamp(2.2rem, 4vw + 1rem, 3.6rem);
-    font-weight: 900;
+    font-weight: 800;
     line-height: 1.05;
     color: var(--text);
     margin: 0;
@@ -99,7 +99,7 @@ h1.header {
     font-size: clamp(1rem, 1.2vw + 0.7rem, 1.35rem);
     line-height: 1.5;
     text-align: center;
-    max-width: 34ch;
+    max-width: 42ch;
 }
 
 .install-button-container {
@@ -205,7 +205,7 @@ h1.header {
     }
 
     .content p {
-        max-width: 32ch;
+        max-width: 40ch;
     }
 
     .previewImage {

--- a/website/style.css
+++ b/website/style.css
@@ -69,8 +69,8 @@ body::-webkit-scrollbar {
 .content > div {
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
-    text-align: left;
+    align-items: center;
+    text-align: center;
     width: 100%;
 }
 
@@ -98,13 +98,13 @@ h1.header {
     color: var(--muted);
     font-size: clamp(1rem, 1.2vw + 0.7rem, 1.35rem);
     line-height: 1.5;
-    text-align: left;
+    text-align: center;
     max-width: 34ch;
 }
 
 .install-button-container {
     display: flex;
-    justify-content: flex-start;
+    justify-content: center;
     width: 100%;
     margin-top: 32px;
 }
@@ -187,6 +187,10 @@ h1.header {
 
 /* Tablet / narrow desktop: stack vertically but keep preview visible */
 @media (max-width: 900px) {
+    .main {
+        padding: 64px 20px 32px;
+    }
+
     .wrapper {
         flex-direction: column;
         gap: 36px;
@@ -200,18 +204,8 @@ h1.header {
         justify-content: center;
     }
 
-    .content > div {
-        align-items: center;
-        text-align: center;
-    }
-
     .content p {
-        text-align: center;
         max-width: 32ch;
-    }
-
-    .install-button-container {
-        justify-content: center;
     }
 
     .previewImage {
@@ -224,7 +218,7 @@ h1.header {
 /* Mobile */
 @media (max-width: 600px) {
     .main {
-        padding: 24px 16px 20px;
+        padding: 64px 16px 20px;
     }
 
     .wrapper {

--- a/website/style.css
+++ b/website/style.css
@@ -75,8 +75,10 @@ body::-webkit-scrollbar {
 }
 
 .header {
+    font-family: 'Archivo', Arial, 'Helvetica Neue', sans-serif;
     font-size: clamp(2.2rem, 4vw + 1rem, 3.6rem);
     font-weight: 800;
+    letter-spacing: -0.02em;
     line-height: 1.05;
     color: var(--text);
     margin: 0;

--- a/website/style.css
+++ b/website/style.css
@@ -101,6 +101,7 @@ h1.header {
     font-size: clamp(1rem, 1.2vw + 0.7rem, 1.35rem);
     line-height: 1.5;
     text-align: center;
+    text-wrap: balance;
     max-width: 42ch;
 }
 
@@ -163,27 +164,65 @@ h1.header {
 }
 
 .footer {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 8px 20px;
-    padding: 16px 20px 22px;
     width: 100%;
-    color: var(--footer-text);
-    opacity: 0.7;
-    font-size: 0.88rem;
-    text-align: center;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    background-color: #0b0b0d;
 }
 
-.footer a {
-    text-decoration: none;
+.footer-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 12px 24px;
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 18px 20px 20px;
+}
+
+.footer-brand {
+    margin: 0;
     color: var(--footer-text);
+    font-size: 0.88rem;
+}
+
+.footer-brand a {
+    color: var(--text);
+    font-weight: bold;
+    text-decoration: none;
+}
+
+.footer-brand a:hover {
+    text-decoration: underline;
+}
+
+.footer-links {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px 20px;
+}
+
+.footer-links a {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--footer-text);
+    font-size: 0.88rem;
+    text-decoration: none;
     transition: color 0.15s ease;
 }
 
-.footer a:hover {
+.footer-links a i {
+    color: var(--accent);
+    font-size: 0.85em;
+}
+
+.footer-links a:hover {
     color: var(--text);
+}
+
+.footer-links a:hover span {
     text-decoration: underline;
 }
 
@@ -234,7 +273,7 @@ h1.header {
     .content p {
         font-size: 1rem;
         line-height: 1.5;
-        max-width: 28ch;
+        max-width: none;
     }
 
     .install-button {
@@ -248,16 +287,21 @@ h1.header {
         max-width: 300px;
     }
 
-    .footer {
+    .footer-inner {
         flex-direction: column;
-        align-items: center;
-        gap: 10px;
+        justify-content: center;
+        text-align: center;
+        gap: 14px;
         padding-bottom: 24px;
-        opacity: 0.65;
     }
 
-    .footer a {
-        margin: 0;
+    .footer-links {
+        order: 1;
+        justify-content: center;
+    }
+
+    .footer-brand {
+        order: 2;
     }
 }
 

--- a/website/style.css
+++ b/website/style.css
@@ -1,18 +1,32 @@
 :root {
     color-scheme: dark;
+    --bg: #0e0e10;
+    --text: #fff;
+    --muted: #a3a3a3;
+    --accent: #9146ff;
+    --accent-hover: #772ce8;
+    --accent-active: #5c16c5;
+    --footer-text: #9a9a9a;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
 }
 
 body {
     padding: 0;
-    margin: 0 auto;
-    background-color: #0e0e10;
-    color: #fff;
+    margin: 0;
+    background-color: var(--bg);
+    color: var(--text);
     font-size: 1rem;
     font-family: Arial, sans-serif;
     display: flex;
     flex-direction: column;
     align-items: center;
     min-height: 100vh;
+    min-height: 100dvh;
 }
 
 body::-webkit-scrollbar {
@@ -20,180 +34,253 @@ body::-webkit-scrollbar {
 }
 
 ::selection {
-    background-color: #9146ff;
+    background-color: var(--accent);
     color: #fff;
 }
 
+/* Main layout */
 .main {
     display: flex;
     flex: 1 0 auto;
     align-items: center;
+    justify-content: center;
     width: 100%;
+    padding: 32px 20px;
 }
 
 .wrapper {
     display: flex;
-    flex-wrap: wrap;
     align-items: center;
-    width: 100%;
-    padding: 10px;
     justify-content: center;
+    gap: 48px 56px;
+    width: 100%;
+    max-width: 1080px;
+    margin: 0 auto;
 }
 
 .content {
     display: flex;
     align-items: center;
-    margin: 10px;
+    flex: 1 1 420px;
+    max-width: 560px;
+    min-width: 0;
 }
 
-.content h1 {
-    margin: 0;
+.content > div {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
     text-align: left;
-}
-
-.content p {
-    margin: 0;
-    padding: 0 10px;
-    color: #a3a3a3;
-    text-align: center;
-    font-size: 1.5rem;
+    width: 100%;
 }
 
 .header {
-    font-size: 4rem;
+    font-size: clamp(2.2rem, 4vw + 1rem, 3.6rem);
     font-weight: 900;
-    text-align: center;
-    color: #fff;
-    margin: 15px 0;
-    margin-top: 150px;
-    padding: 0 10px;
+    line-height: 1.05;
+    color: var(--text);
+    margin: 0;
+    padding: 0;
     user-select: none;
 }
 
+h1.header {
+    margin: 0;
+}
+
 .accent-color {
-    color: #9146ff;
+    color: var(--accent);
+}
+
+.content p {
+    margin: 14px 0 0;
+    padding: 0;
+    color: var(--muted);
+    font-size: clamp(1rem, 1.2vw + 0.7rem, 1.35rem);
+    line-height: 1.5;
+    text-align: left;
+    max-width: 34ch;
 }
 
 .install-button-container {
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
+    width: 100%;
+    margin-top: 32px;
 }
 
 .install-button {
-    margin-top: 40px;
-    padding: 15px 30px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 15px 28px;
     border: 0;
     border-radius: 8px;
-    background-color: #9146ff;
+    background-color: var(--accent);
     color: #fff;
-    font-size: 1.5rem;
+    font-size: 1.15rem;
     font-weight: bold;
     text-decoration: none;
     user-select: none;
+    line-height: 1;
+    white-space: nowrap;
+    transition: background-color 0.15s ease;
 }
 
 .install-button:hover {
-  background-color: #772ce8;
+    background-color: var(--accent-hover);
 }
 
 .install-button:active {
-  background-color: #5c16c5;
+    background-color: var(--accent-active);
+}
+
+.install-button i {
+    font-size: 1.25em;
 }
 
 .previewImage {
-    margin: 10px;
+    flex: 0 1 430px;
+    max-width: 430px;
+    width: 100%;
+    min-width: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 .previewImage img {
-    border-radius: 5px;
-}
-
-.previewImage p {
-    color: var(--secondary-text);
-    margin: 4px 0;
+    display: block;
+    width: 100%;
+    height: auto;
+    max-width: 100%;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.55);
 }
 
 .footer {
-    padding-bottom: 10px;
-    color: var(--secondary-text);
-    opacity: .5;
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px 20px;
+    padding: 16px 20px 22px;
+    width: 100%;
+    color: var(--footer-text);
+    opacity: 0.7;
+    font-size: 0.88rem;
+    text-align: center;
 }
 
 .footer a {
     text-decoration: none;
-    text-align: center;
-    color: var(--secondary-text);
-    margin-right: 15px;
+    color: var(--footer-text);
+    transition: color 0.15s ease;
 }
 
 .footer a:hover {
+    color: var(--text);
     text-decoration: underline;
 }
 
-
-@media (max-width: 1150px) {
+/* Tablet / narrow desktop: stack vertically but keep preview visible */
+@media (max-width: 900px) {
     .wrapper {
+        flex-direction: column;
+        gap: 36px;
+        max-width: 640px;
+    }
+
+    .content {
+        flex: 0 1 auto;
+        max-width: 560px;
+        width: 100%;
         justify-content: center;
     }
 
-    .content h1 {
-        text-align: center;
-    }
-
-    .previewImage {
-        display: none;
-    }
-}
-
-@media (max-width: 700px) {
-    .wrapper {
-        justify-content: center;
-    }
-
-    .content{
+    .content > div {
+        align-items: center;
         text-align: center;
     }
 
     .content p {
-        font-size: 0.8rem;
+        text-align: center;
+        max-width: 32ch;
     }
 
-    .header {
-        font-size: 2rem;
-    }
-
-    .install-button {
-        margin-top: 20px;
-        padding: 10px 15px;
-        font-size: 1rem;
+    .install-button-container {
+        justify-content: center;
     }
 
     .previewImage {
-        display: none;
+        flex: 0 1 auto;
+        max-width: 380px;
+        width: 100%;
+    }
+}
+
+/* Mobile */
+@media (max-width: 600px) {
+    .main {
+        padding: 24px 16px 20px;
+    }
+
+    .wrapper {
+        gap: 28px;
+    }
+
+    .header {
+        font-size: clamp(1.9rem, 8vw, 2.6rem);
+    }
+
+    .content p {
+        font-size: 1rem;
+        line-height: 1.5;
+        max-width: 28ch;
+    }
+
+    .install-button {
+        padding: 13px 22px;
+        font-size: 1rem;
+        width: 100%;
+        max-width: 320px;
+    }
+
+    .previewImage {
+        max-width: 300px;
     }
 
     .footer {
         flex-direction: column;
-        padding-bottom: 20px;
+        align-items: center;
+        gap: 10px;
+        padding-bottom: 24px;
+        opacity: 0.65;
     }
 
     .footer a {
-    margin-top: 10px;
-    margin-right: 0;
+        margin: 0;
     }
 }
 
 @media (max-width: 380px) {
     .header {
-        font-size: 1.6rem;
+        font-size: 1.7rem;
+    }
+
+    .content p {
+        font-size: 0.95rem;
     }
 
     .install-button {
-        margin-top: 15px;
-        padding: 8px 10px;
-        border-radius: 6px;
-        font-size: 0.8rem;
+        padding: 11px 16px;
+        font-size: 0.95rem;
+        border-radius: 7px;
+    }
+
+    .previewImage {
+        max-width: 260px;
     }
 }


### PR DESCRIPTION
## What & why
Landing-page polish pass: fluid responsive layout (preview stays visible on mobile instead of `display: none`), semantic + accessibility fixes, Archivo ExtraBold header matching `link-preview.png`, tagline tuned to two balanced lines, and a redesigned footer (brand bar with icon links, device-local © year with 2026 fallback).

## Touched areas
- website/index.html — `lang`, `h1` semantics, img alt/dimensions/loading, `aria-hidden`, `rel="noopener"`, Archivo font link, semantic `footer` + `nav`, dynamic year script
- website/style.css — CSS vars, `dvh`, `clamp()` type, centered hero, scaled preview image, new footer bar, balanced tagline wrapping

## Screenshots / video
Skipped — reviewed live on-device via local server at desktop + phone widths.

## Checklist
- [ ] manifest.json version bumped if user-visible change (and CHANGELOG.md updated) — N/A, Pages-only change
- [x] Tested via Load unpacked in chrome://extensions (auth, search, sort, settings, context menu, badge) — N/A for extension; page reviewed on-device via local server at desktop + mobile widths
- [x] CI is green on the latest commit

---
Built with muse-spark-1.3-contributor-free in the OpenCode harness.
