### PR TITLE
docs(readme): polish credits, privacy, permissions and local-install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,43 +15,56 @@
   </p>
 </div>
 
-This extension brings the channels you follow to the forefront, providing a seamless viewing experience right from your browser.
+Sam's Twitch Live surfaces the channels you follow that are currently live — searchable, sortable, and one click away from the stream, player, or chat.
 
 ### Key Features
-- _**Live Following Channels:**_ Keep track of the live channels you follow on Twitch with ease.
-- _**Customizable Viewing Options:**_ Tailor your viewing experience by choosing to open streams in a new window or in the player. Customize background update intervals, badge color, layout options and more.
-- _**Quick Search:**_ Effortlessly find your preferred streams with the built-in search functionality.
-- _**Sort Streams:**_ Sort streams based on various criteria, including Viewers (High to Low or Low to High), Broadcasters, Categories, Recently Started, and Longest Running.
-- _**Context Menu:**_ Enhance your browsing experience with a right-click context menu that allows you to open streams channel, player, or chat. Additionally, you can directly access channel's about, videos, and clips pages. Explore streams by category with ease using context menu.
+- **Live follow list:** see every followed channel that is live right now, with title, category, viewer count, and uptime.
+- **Quick search:** find streams by channel name, title, or category.
+- **Sorting:** Broadcaster, Category, Viewers (High to Low or Low to High), Recently Started, and Longest Running. Your choice is remembered between sessions.
+- **Context menu:** right-click a stream to open its channel, player, or chat; jump to its About, Videos, or Clips pages; or browse more streams in its category.
+- **Raid helper:** optional one-click button copies the `/raid` command for a channel.
+- **Customizable:** Simple view (hides thumbnails and uptime), open-in-player, open-in-new-window, background refresh interval, custom badge color, and more.
+- **Background updates:** the toolbar badge keeps count of live channels on your schedule, even while the popup is closed. The open popup refreshes every 30 seconds.
 
 ## Install
 
 <a href="https://chromewebstore.google.com/detail/sams-twitch-live/fnaolpkjdickppbebcafdajjndmkgbei">
 	<img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome.svg" width="48" alt="Chrome" valign="middle"> <b>Chrome</b>
 </a>
-or any chromium-based browsers (e.g. Brave, Edge, Opera)
+or any Chromium-based browser (e.g. Brave, Edge, Opera)
 <br>
 <br>
 
-Guide for [how to install and test](https://github.com/yungsamd17/Twitch-Live/blob/main/docs/INSTALL_FROM_STORAGE.md)  the extension locally
+See the [local install and testing guide](docs/INSTALL_FROM_STORAGE.md) to run the extension unpacked from source.
 
-### How to Use
+## How to Use
 1. Log in with your Twitch account to authenticate the extension.
-2. Explore your live following channels directly from the extension popup.
+2. Explore your live followed channels directly from the extension popup.
 3. Customize your viewing preferences in the settings for an optimal experience.
-4. Enjoy uninterrupted Twitch streaming without leaving your Chrome browser.
+4. Enjoy uninterrupted Twitch streaming without leaving your browser.
+
+## Privacy
+
+- Sign-in uses Twitch OAuth with read-only access to your follows (`user:read:follows`). Nothing is ever posted to or changed on your account.
+- Your access token and cached stream list are stored only in the extension's local browser storage. There is no analytics, tracking, or external server — the extension talks directly to the Twitch API.
+- Logging out clears the token and cached data from local storage.
+
+## Permissions
+
+- `alarms` — refresh live streams in the background and re-check your login hourly.
+- `storage` — remember your settings, cached streams, and login token locally.
+- `identity` — sign you in with Twitch via OAuth.
+- Host access to `api.twitch.tv` and `id.twitch.tv` — fetch live streams and validate your login. Nothing else.
 
 ## Contributing
-To contribute, simply fork this project and create a pull request with your changes. Whether it's a new feature, bug fix, or documentation improvement, we appreciate all contributions. Thank you for your interest in helping to make this project even better!
+Contributions are welcome, whether it's a new feature, bug fix, or documentation improvement. Fork the repo, create a focused branch, and open a pull request against `main`. Small, single-concern PRs with a short description and testing notes get merged fastest, and CI must pass before merging. Thank you for helping make this project better!
 
 ## Credits
 
-Forked originally from [MatthewMoye/who-is-live](https://github.com/MatthewMoye/who-is-live)
+Originally based on [MatthewMoye/who-is-live](https://github.com/MatthewMoye/who-is-live) — since heavily rewritten (Twitch-only, Manifest V3, new UI and features).
 
-### Contributions
-
-- [**xezrunner**](https://github.com/xezrunner) For helping with migration to Manifest V3 and much more.
+Thanks to [**xezrunner**](https://github.com/xezrunner) for helping with the Manifest V3 migration and much more.
 
 ## License
 
-This software is released under the terms of the MIT License. See the [LICENSE](https://github.com/yungsamd17/Twitch-Live/blob/main/LICENSE) for further information.
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details, and [CHANGELOG.md](CHANGELOG.md) for release history.

--- a/docs/INSTALL_FROM_STORAGE.md
+++ b/docs/INSTALL_FROM_STORAGE.md
@@ -32,9 +32,15 @@ This is done for security reasons from Twitch's side. Not registering your local
 
 4. Under **Category**, select **Browser Extension**.  
    Under **Client Type**, select **Confidential**, then press **Create**.
-5. After creating the Application, copy the **Client ID**.
-6. Open `background.js` in any text/code editor and replace existing `TWITCH_APP_TOKEN` value with the copied value.
+5. After creating the Application, copy the **Client ID** (a public application identifier, not a secret).
+6. Open `src/js/background.js` in any text/code editor and replace the existing `TWITCH_APP_TOKEN` value with the copied value.
 7. Refresh the extension on the Extensions page with the refresh button.
 8. Open the extension and log in with your account.
 
 Happy testing!
+
+## Troubleshooting
+
+- **Login fails or loops back to the login screen:** your extension ID most likely isn't registered, or it changed after reinstalling the extension. Re-check step 3 — the redirect URL must exactly match `https://YOUR-EXTENSION-ID.chromiumapp.org/`.
+- **Logged out unexpectedly:** Twitch tokens expire or get revoked. The extension re-checks your login hourly and signs you out if Twitch rejects it — just log in again.
+- **No live channels showing:** make sure you're logged in and follow channels that are currently live. Press the popup's refresh button; fresh data otherwise arrives on the background schedule (every 5 minutes by default, configurable in the extension settings).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,4 @@
 # Documentation
 
-- [Guide to install and test the extension locally](https://github.com/yungsamd17/Twitch-Live/blob/main/docs/INSTALL_FROM_STORAGE.md)
+- [Installing and testing the extension locally](INSTALL_FROM_STORAGE.md) — load the unpacked extension, register your extension ID with Twitch, and log in.
+- [Changelog](../CHANGELOG.md) — release history and what changed in each version.


### PR DESCRIPTION
What changed and why: README and docs were stale and partly inaccurate (credits misused GitHub's "Forked" term, install guide pointed at a wrong file path). This brings them in line with the current MV3 codebase.

- README: credits reworded to "Originally based on", features rewritten to match code (sort orders, search scope, context-menu items, raid helper, refresh cadence), new Privacy and Permissions sections, relative internal links, heading/grammar fixes
- docs/INSTALL_FROM_STORAGE.md: fixed token path to src/js/background.js, noted Client ID is public, added Troubleshooting section
- docs/README.md: expanded into an index with changelog link

Testing:
- [x] Verified all relative links resolve (LICENSE, CHANGELOG.md, docs/INSTALL_FROM_STORAGE.md)
- [x] Verified documented facts against source (TWITCH_APP_TOKEN in src/js/background.js:90, 30s popup refresh, 5-min default background interval, OAuth scope)
- [x] manifest.json still valid JSON; LICENSE and manifest untouched
- [ ] CI must pass before merging

Built with muse-spark-1.3-contributor-free in the OpenCode harness.